### PR TITLE
feat(docs): add code of conduct and contribution guide

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant 3.0 Code of Conduct
+
+## Our Pledge
+
+We pledge to make our community welcoming, safe, and equitable for all.
+
+We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
+
+## Encouraged Behaviors
+
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
+
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
+
+1. Respecting the **purpose of our community**, our activities, and our ways of gathering.
+2. Engaging **kindly and honestly** with others.
+3. Respecting **different viewpoints** and experiences.
+4. **Taking responsibility** for our actions and contributions.
+5. Gracefully giving and accepting **constructive feedback**.
+6. Committing to **repairing harm** when it occurs.
+7. Behaving in other ways that promote and sustain the **well-being of our community**.
+
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
+
+1. **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
+2. **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+3. **Stereotyping or discrimination.** Characterizing anyone’s personality or behavior on the basis of immutable identities or traits.
+4. **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+5. **Violating confidentiality**. Sharing or acting on someone's personal or private information without their permission.
+6. **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person or group.
+7. Behaving in other ways that **threaten the well-being** of our community.
+
+### Other Restrictions
+
+1. **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
+2. **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+3. **Promotional materials**. Sharing marketing or other commercial content in a way that is outside the norms of the community.
+4. **Irresponsible communication.** Failing to responsibly present content which includes, links or describes any other restricted behaviors.
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+When an incident does occur, it is important to report it promptly. To report a possible violation, contact the project stewards (@9romise and @danielroe) by DM in our community chat. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project stewards are obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
+
+## Addressing and Repairing Harm
+
+If an investigation by the Community Moderators finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident's impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.
+
+1. Warning
+   1. Event: A violation involving a single incident or series of incidents.
+   2. Consequence: A private, written warning from the Community Moderators.
+   3. Repair: Examples of repair include a private written apology, acknowledgement of responsibility, and seeking clarification on expectations.
+2. Temporarily Limited Activities
+   1. Event: A repeated incidence of a violation that previously resulted in a warning, or the first incidence of a more serious violation.
+   2. Consequence: A private, written warning with a time-limited cooldown period designed to underscore the seriousness of the situation and give the community members involved time to process the incident. The cooldown period may be limited to particular communication channels or interactions with particular community members.
+   3. Repair: Examples of repair may include making an apology, using the cooldown period to reflect on actions and impact, and being thoughtful about re-entering community spaces after the period is over.
+3. Temporary Suspension
+   1. Event: A pattern of repeated violation which the Community Moderators have tried to address with warnings, or a single serious violation.
+   2. Consequence: A private written warning with conditions for return from suspension. In general, temporary suspensions give the person being suspended time to reflect upon their behavior and possible corrective actions.
+   3. Repair: Examples of repair include respecting the spirit of the suspension, meeting the specified conditions for return, and being thoughtful about how to reintegrate with the community when the suspension is lifted.
+4. Permanent Ban
+   1. Event: A pattern of repeated code of conduct violations that other steps on the ladder have failed to resolve, or a violation so serious that the Community Moderators determine there is no way to keep the community safe with this person as a member.
+   2. Consequence: Access to all community spaces, tools, and communication channels is removed. In general, permanent bans should be rarely used, should have strong reasoning behind them, and should only be resorted to if working through other remedies has failed to change the behavior.
+   3. Repair: There is no possible repair in cases of this severity.
+
+This enforcement ladder is intended as a guideline. It does not limit the ability of Community Managers to use their discretion and judgment, in keeping with the best interests of our community.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently available at [https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/).
+
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under CC BY-SA 4.0. To view a copy of this license, visit [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/)
+
+For answers to common questions about Contributor Covenant, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are provided at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Additional enforcement and community guideline resources can be found at [https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources). The enforcement ladder was inspired by the work of [Mozilla’s code of conduct team](https://github.com/mozilla/inclusion).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,236 @@
+# Contributing to vscode-npmx
+
+Thank you for your interest in contributing! ❤️ This document provides guidelines and instructions for contributing.
+
+> [!IMPORTANT]
+> Please be respectful and constructive in all interactions. We aim to maintain a welcoming environment for all contributors.
+> [👉 Read more](./CODE_OF_CONDUCT.md)
+
+## Goals
+
+The goal of [vscode-npmx](https://marketplace.visualstudio.com/items?itemName=npmx-dev.vscode-npmx) is to build a useful extension around [npmx.dev](https://npmx.dev), making it easier for developers to manage npm packages within VS Code.
+
+## Table of Contents
+
+- [Getting started](#getting-started)
+  - [Prerequisites](#prerequisites)
+  - [Setup](#setup)
+- [Development workflow](#development-workflow)
+  - [Available commands](#available-commands)
+  - [Project structure](#project-structure)
+- [Code style](#code-style)
+  - [TypeScript](#typescript)
+  - [Import order](#import-order)
+  - [Naming conventions](#naming-conventions)
+- [Testing](#testing)
+  - [Unit tests](#unit-tests)
+- [Submitting changes](#submitting-changes)
+  - [Before submitting](#before-submitting)
+  - [Pull request process](#pull-request-process)
+  - [Commit messages and PR titles](#commit-messages-and-pr-titles)
+- [Pre-commit hooks](#pre-commit-hooks)
+- [Using AI](#using-ai)
+- [Questions](#questions)
+- [License](#license)
+
+## Getting started
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) (LTS version recommended)
+- [pnpm](https://pnpm.io/) v10.28.1 or later
+
+### Setup
+
+1. fork and clone the repository
+2. install dependencies:
+
+   ```bash
+   pnpm install
+   ```
+
+3. start the development server:
+
+   ```bash
+   pnpm dev
+   ```
+
+4. Press `F5` to open the VS Code debugger and start the extension in a new VS Code window.
+
+## Development workflow
+
+### Available commands
+
+```bash
+# Development
+pnpm dev              # Start development server
+pnpm build            # Production build
+pnpm package          # Save extension as vsix file to root
+
+# Code Quality
+pnpm lint             # Run linter (oxlint + oxfmt)
+pnpm lint:fix         # Auto-fix lint issues
+pnpm typecheck        # TypeScript type checking
+
+# Testing
+pnpm test             # Run tests
+```
+
+### Project structure
+
+```
+playground/             # Playground for testing
+res/                    # Assets (e.g. marketplace icon)
+src/                    # Extension source code
+├── extractors/         # Extractors
+├── providers/          # Providers
+├── types/              # TypeScript types
+├── utils/              # Utility functions
+├── constants.ts        # Constants
+├── state.ts            # State management
+└── index.ts            # Extension entry point
+tests/                  # Tests
+```
+
+## Code style
+
+When committing changes, try to keep an eye out for unintended formatting updates. These can make a pull request look noisier than it really is and slow down the review process. Sometimes IDEs automatically reformat files on save, which can unintentionally introduce extra changes.
+
+If you want to get ahead of any formatting issues, you can also run `pnpm lint:fix` before committing to fix formatting across the whole project.
+
+### TypeScript
+
+- We care about good types &ndash; never cast things to `any` 💪
+- Validate rather than just assert
+
+### Import order
+
+1. Type imports first (`import type { ... }`)
+2. Internal aliases (`#constants`, `#utils/`, etc.)
+3. External packages (including `node:`)
+4. Relative imports (`./`, `../`)
+5. No blank lines between groups
+
+```typescript
+import type { PackageVersionsInfoWithMetadata } from 'fast-npm-meta'
+import { logger } from '#state'
+import { getVersions } from 'fast-npm-meta'
+import { memoize } from '../memoize'
+```
+
+### Naming conventions
+
+| Type             | Convention           | Example                                       |
+| ---------------- | -------------------- | --------------------------------------------- |
+| Files/Folders    | kebab-case           | `package-json.ts`, `pnpm-workspace-yaml.ts`   |
+| Test files       | kebab-case + `.test` | `memoize.test.ts`                             |
+| Functions        | camelCase            | `fetchPackage`, `formatDate`                  |
+| Constants        | SCREAMING_SNAKE_CASE | `NPM_REGISTRY`, `ALLOWED_TAGS`                |
+| Types/Interfaces | PascalCase           | `NpmSearchResponse`, `Extractor`, `ValidNode` |
+
+## Testing
+
+### Unit tests
+
+Write unit tests for core functionality using Vitest:
+
+```typescript
+import { describe, it, expect } from 'vitest'
+
+describe('featureName', () => {
+  it('should handle expected case', () => {
+    expect(result).toBe(expected)
+  })
+})
+```
+
+## Submitting changes
+
+### Before submitting
+
+1. ensure your code follows the style guidelines
+2. run linting: `pnpm lint:fix`
+3. run type checking: `pnpm typecheck`
+4. run tests: `pnpm test`
+5. write or update tests for your changes
+
+### Pull request process
+
+1. create a feature branch from `main`
+2. make your changes with clear, descriptive commits
+3. push your branch and open a pull request
+4. ensure CI checks pass (lint, type check, tests)
+5. request review from maintainers
+
+### Commit messages and PR titles
+
+Write clear, concise PR titles that explain the "why" behind changes.
+
+We use [Conventional Commits](https://www.conventionalcommits.org/). Since we squash on merge, the PR title becomes the commit message in `main`, so it's important to get it right.
+
+Format: `type(scope): description`
+
+**Types:** `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
+
+**Scopes (optional):** `docs`, `i18n`, `deps`
+
+**Examples:**
+
+- `fix: resolve search pagination issue`
+- `feat: add package version comparison`
+- `fix(i18n): update French translations`
+- `chore(deps): update vite to v6`
+
+> [!NOTE]
+> The subject must start with a lowercase letter. Individual commit messages within your PR don't need to follow this format since they'll be squashed.
+
+### PR descriptions
+
+If your pull request directly addresses an open issue, use the following inside your PR description.
+
+```text
+Resolves | Fixes | Closes: #xxx
+```
+
+Replace `#xxx` with either a URL to the issue, or the number of the issue. For example:
+
+```text
+Fixes:#123
+```
+
+or
+
+```text
+Closes https://github.com/npmx-dev/vscode-npmx/issues/123
+```
+
+This provides the following benefits:
+
+- it links the pull request to the issue (the merge icon will appear in the issue), so everybody can see there is an open PR
+- when the pull request is merged, the linked issue is automatically closed
+
+## Pre-commit hooks
+
+The project uses `nano-staged` with `husky` to automatically lint files on commit.
+
+## Using AI
+
+You're welcome to use AI tools to help you contribute. But there are two important ground rules:
+
+### 1. Never let an LLM speak for you
+
+When you write a comment, issue, or PR description, use your own words. Grammar and spelling don't matter &ndash; real connection does. AI-generated summaries tend to be long-winded, dense, and often inaccurate. Simplicity is an art. The goal is not to sound impressive, but to communicate clearly.
+
+### 2. Never let an LLM think for you
+
+Feel free to use AI to write code, tests, or point you in the right direction. But always understand what it's written before contributing it. Take personal responsibility for your contributions. Don't say "ChatGPT says..." &ndash; tell us what _you_ think.
+
+For more context, see [Using AI in open source](https://roe.dev/blog/using-ai-in-open-source).
+
+## Questions?
+
+If you have questions or need help, feel free to open an issue for discussion or join our [Discord server](https://chat.npmx.dev).
+
+## License
+
+By contributing to vscode-npmx, you agree that your contributions will be licensed under the [MIT License](LICENSE).  

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@
 
 <!-- configs -->
 
+## Contributing
+
+Contributions are welcome! Please review our [contribution guide](./CONTRIBUTING.md) for more details.
+
 ## License
 
 [MIT](./LICENSE) License &copy; 2026-PRESENT [Vida Xie](https://github.com/9romise)


### PR DESCRIPTION
To improve outreach, I kickstarted some contribution guidelines:

- Added the same code of conduct as [npmx](https://github.com/npmx-dev/npmx.dev/blob/main/CODE_OF_CONDUCT.md)
- Adapted npmx contribution guide for this project, suggestions for improvement welcome!
- Added link to contribution guide to readme
