### PR TITLE
fix(diagnostics): clean up on tab closed

### DIFF
--- a/src/providers/diagnostics/index.ts
+++ b/src/providers/diagnostics/index.ts
@@ -62,7 +62,7 @@ export function useDiagnostics() {
 
   async function collectDiagnostics(document: TextDocument, extractor: Extractor) {
     logger.info(`[diagnostics] collect: ${document.uri.path}`)
-    diagnosticCollection.delete(document.uri)
+    diagnosticCollection.set(document.uri, [])
 
     const rules = enabledRules.value
     if (rules.length === 0)
@@ -143,7 +143,10 @@ export function useDiagnostics() {
     collectDiagnostics(document, extractor)
   }, { immediate: true })
 
-  async function collectDiagnosticsByUri(uri: Uri, extractor: Extractor) {
+  async function recollectByUri(uri: Uri, extractor: Extractor) {
+    if (!diagnosticCollection.has(uri))
+      return
+
     const doc = await workspace.openTextDocument(uri)
 
     collectDiagnostics(doc, extractor)
@@ -152,8 +155,8 @@ export function useDiagnostics() {
   extractorEntries.forEach(({ pattern, extractor }) => {
     const { onDidCreate, onDidChange, onDidDelete } = useFileSystemWatcher(pattern)
 
-    onDidCreate((uri) => collectDiagnosticsByUri(uri, extractor))
-    onDidChange((uri) => collectDiagnosticsByUri(uri, extractor))
+    onDidCreate((uri) => recollectByUri(uri, extractor))
+    onDidChange((uri) => recollectByUri(uri, extractor))
     onDidDelete((uri) => diagnosticCollection.delete(uri))
   })
 


### PR DESCRIPTION
fixes #57 

- Cleanup diagnostics on tab closed
- Watch files create/change (triggered by `npm i`, `git pull`)

During exploration, I found that `vscode-cspell-checker` and `vscode-eslint` handle file close events in VS Code via the LSP to clear diagnostics. Though I'm not entirely sure if we need to migrate to an LSP‑based approach just yet. 🤔