### PR TITLE
fix: handle windows paths in umd-to-esm

### DIFF
--- a/plugins/umd-to-esm.ts
+++ b/plugins/umd-to-esm.ts
@@ -21,7 +21,7 @@ export function umdToEsm(): Rolldown.RolldownPlugin {
         id: targets,
       },
       handler(source, importer) {
-        const require = createRequire(importer!)
+        const require = createRequire(importer ?? import.meta.url)
         const resolvedModulePath = require.resolve(source)
         const resolvedEsmPath = toEsmPath(resolvedModulePath)
         return { id: resolvedEsmPath }

--- a/plugins/umd-to-esm.ts
+++ b/plugins/umd-to-esm.ts
@@ -7,6 +7,12 @@ const targets = [
   /^jsonc-parser$/,
 ]
 
+const UMD_SEGMENT_PATTERN = /[/\\]umd[/\\]/
+
+export function toEsmPath(resolvedModulePath: string) {
+  return resolvedModulePath.replace(UMD_SEGMENT_PATTERN, (matchedSegment) => matchedSegment.replace('umd', 'esm'))
+}
+
 export function umdToEsm(): Rolldown.RolldownPlugin {
   return {
     name: 'umd-to-esm',
@@ -16,9 +22,9 @@ export function umdToEsm(): Rolldown.RolldownPlugin {
       },
       handler(source, importer) {
         const require = createRequire(importer!)
-        const pathUmdMay = require.resolve(source)
-        const pathEsm = pathUmdMay.replace('/umd/', '/esm/')
-        return { id: pathEsm }
+        const resolvedModulePath = require.resolve(source)
+        const resolvedEsmPath = toEsmPath(resolvedModulePath)
+        return { id: resolvedEsmPath }
       },
     },
   }


### PR DESCRIPTION
The previous replacement only matched `/umd/`, so Windows paths were not converted to the ESM entry. This caused the built language server to load the wrong `jsonc-parser` bundle and fail at startup.