### PR TITLE
ci(dependabot): apply playground exclusions to npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: weekly
 
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
     # Ignore all dependency manifests in the `playground` directory.
     exclude-paths:
       - playground/**


### PR DESCRIPTION
Follow up on #105 to clarify and fix how `exclude-paths` is applied in Dependabot.

The previous change added `exclude-paths` for the `github-actions` ecosystem, but that only affects workflow/action updates under `.github/workflows`. It does not apply to package manifests such as `package.json`.

Since Dependabot handles `npm`, `yarn`, and `pnpm` manifests under the `npm` ecosystem, dependency updates in `playground/**` could still trigger PRs, such as the recent `playground/yarn` axios update.