### PR TITLE
ci: add ignore rule for playground/** dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,18 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    # Ignore all dependency manifests in the `playground` directory.
+    # exclude-paths only prevents version updates, not security updates.
     exclude-paths:
       - playground/**
+
+  # Playground directories use intentionally outdated/vulnerable versions
+  # to test the extension's diagnostics features.
+  # `ignore` is required because `exclude-paths` does NOT prevent security updates.
+  - package-ecosystem: npm
+    directories:
+      - playground/**
+    schedule:
+      interval: weekly
+    ignore:
+      - dependency-name: "*"
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,4 +23,3 @@ updates:
       interval: weekly
     ignore:
       - dependency-name: '*'
-

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,5 +22,5 @@ updates:
     schedule:
       interval: weekly
     ignore:
-      - dependency-name: "*"
+      - dependency-name: '*'
 


### PR DESCRIPTION
Follow-up to #108.

After #108, Dependabot was still opening security update PRs for `playground/yarn`.

`exclude-paths` only prevents version updates. It does not block security updates, so `playground/yarn` still needed a dedicated `ignore` rule.

This change adds that ignore configuration so updates under `playground/yarn` no longer create Dependabot PRs.
