### PR TITLE
feat: upgrade `fast-npm-meta` 1.5.1 -> 2.1.0

### DIFF
--- a/packages/language-core/package.json
+++ b/packages/language-core/package.json
@@ -41,7 +41,7 @@
     "yaml": "catalog:inline"
   },
   "inlinedDependencies": {
-    "fast-npm-meta": "1.5.1",
+    "fast-npm-meta": "2.1.0",
     "jsonc-parser": "3.3.1",
     "module-replacements": "3.0.0-beta.7",
     "ofetch": "2.0.0-alpha.3",

--- a/packages/language-service/src/plugins/hover.test.ts
+++ b/packages/language-service/src/plugins/hover.test.ts
@@ -11,6 +11,8 @@ const packageInfo = {
   versionsMeta: {
     '1.0.0': {
       provenance: true,
+      trustedPublisher: true,
+      staged: true,
     },
   },
   timeCreated: '2026-01-01T00:00:00.000Z',
@@ -40,7 +42,7 @@ function createDependency(overrides: Partial<DependencyInfo> = {}): DependencyIn
 describe('renderHoverMarkdown', () => {
   it('renders codicon markup for codicon-capable clients', async () => {
     await expect(renderHoverMarkdown(createDependency(), 'codicon')).resolves.toMatchInlineSnapshot(`
-      "[$(verified)&nbsp;Verified provenance](https://npmx.dev/package/lodash/v/^1.0.0#provenance)
+      "[$(verified)&nbsp;Verified provenance](https://npmx.dev/package/lodash/v/^1.0.0#provenance) · $(workspace-trusted)&nbsp;Trusted publisher · $(session-in-progress)&nbsp;Staged
 
       [$(package)&nbsp;View on npmx.dev](https://npmx.dev/package/lodash) | [$(book)&nbsp;View docs on npmx.dev](https://npmx.dev/docs/lodash/v/^1.0.0)"
     `)
@@ -48,7 +50,7 @@ describe('renderHoverMarkdown', () => {
 
   it('renders emoji icons for non-codicon clients', async () => {
     await expect(renderHoverMarkdown(createDependency(), 'emoji')).resolves.toMatchInlineSnapshot(`
-      "[✅ Verified provenance](https://npmx.dev/package/lodash/v/^1.0.0#provenance)
+      "[✅ Verified provenance](https://npmx.dev/package/lodash/v/^1.0.0#provenance) · 🔑 Trusted publisher · 🚧 Staged
 
       [📦 View on npmx.dev](https://npmx.dev/package/lodash) | [📖 View docs on npmx.dev](https://npmx.dev/docs/lodash/v/^1.0.0)"
     `)

--- a/packages/language-service/src/plugins/hover.ts
+++ b/packages/language-service/src/plugins/hover.ts
@@ -12,6 +12,8 @@ const ICONS = {
   verified: { codicon: 'verified', emoji: '✅' },
   book: { codicon: 'book', emoji: '📖' },
   warning: { codicon: 'warning', emoji: '⚠️' },
+  trusted: { codicon: 'workspace-trusted', emoji: '🔑' },
+  staged: { codicon: 'session-in-progress', emoji: '🚧' },
 } as const
 
 type IconName = keyof typeof ICONS
@@ -21,13 +23,6 @@ function iconLabel(iconStyle: IconStyle, name: IconName, label: string): string 
   return iconStyle === 'codicon'
     ? `$(${codicon})&nbsp;${label}`
     : `${emoji} ${label}`
-}
-
-function iconText(iconStyle: IconStyle, name: IconName, text: string): string {
-  const { codicon, emoji } = ICONS[name]
-  return iconStyle === 'codicon'
-    ? `$(${codicon}) ${text}`
-    : `${emoji} ${text}`
 }
 
 function markdownLink(label: string, url: string): string {
@@ -44,20 +39,32 @@ export async function renderHoverMarkdown(dep: DependencyInfo, iconStyle: IconSt
         jsrPackageUrl(resolvedName),
       )
 
-      return `${jsrPackageLink} | ${iconText(iconStyle, 'warning', 'Not on npmx.dev')}`
+      return `${jsrPackageLink} | ${iconLabel(iconStyle, 'warning', 'Not on npmx.dev')}`
     }
     case 'npm': {
       const pkg = await packageInfo()
       if (!pkg)
-        return iconText(iconStyle, 'warning', 'Unable to fetch package information.')
+        return iconLabel(iconStyle, 'warning', 'Unable to fetch package information.')
 
       const resolvedVersion = await dep.resolvedVersion()
       let content = ''
-      if (resolvedVersion && pkg.versionsMeta[resolvedVersion]?.provenance) {
-        content += `${markdownLink(
-          iconLabel(iconStyle, 'verified', 'Verified provenance'),
-          `${npmxPackageUrl(resolvedName, resolvedSpec)}#provenance`,
-        )}\n\n`
+      if (resolvedVersion) {
+        const meta = pkg.versionsMeta[resolvedVersion]
+        const badges: string[] = []
+        if (meta?.provenance) {
+          badges.push(markdownLink(
+            iconLabel(iconStyle, 'verified', 'Verified provenance'),
+            `${npmxPackageUrl(resolvedName, resolvedSpec)}#provenance`,
+          ))
+        }
+        if (meta?.trustedPublisher) {
+          badges.push(iconLabel(iconStyle, 'trusted', 'Trusted publisher'))
+        }
+        if (meta?.staged) {
+          badges.push(iconLabel(iconStyle, 'staged', 'Staged'))
+        }
+        if (badges.length > 0)
+          content += `${badges.join(' · ')}\n\n`
       }
 
       const packageLink = markdownLink(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,8 +41,8 @@ catalogs:
       version: 1.6.0
   inline:
     fast-npm-meta:
-      specifier: ^1.5.1
-      version: 1.5.1
+      specifier: ^2.1.0
+      version: 2.1.0
     jsonc-parser:
       specifier: ^3.3.1
       version: 3.3.1
@@ -194,7 +194,7 @@ importers:
     devDependencies:
       fast-npm-meta:
         specifier: catalog:inline
-        version: 1.5.1
+        version: 2.1.0
       jsonc-parser:
         specifier: catalog:inline
         version: 3.3.1
@@ -1399,8 +1399,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-npm-meta@1.5.1:
-    resolution: {integrity: sha512-tWhw7z4jFuQgZB9tbQyUh5BY9nNd/wimM+fBLfmmJjakkJDNvbJKm0nQ5ruPKC0us1HGg7L6iBk1fxpSzcgSaA==}
+  fast-npm-meta@2.1.0:
+    resolution: {integrity: sha512-Nfk1zTQvBmvh1XMxh9VkxMfRLHgv61YlIW80s4l/ZQVUbV4k4M5HjuQLlL8TooYD0AsSl19p4DU63wHZqZ0y9Q==}
     hasBin: true
 
   fast-string-truncated-width@3.0.3:
@@ -2158,6 +2158,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -3618,7 +3619,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-npm-meta@1.5.1: {}
+  fast-npm-meta@2.1.0: {}
 
   fast-string-truncated-width@3.0.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ catalogs:
     vite: ^8.0.13
     vscode-ext-gen: ^1.6.0
   inline:
-    fast-npm-meta: ^1.5.1
+    fast-npm-meta: ^2.1.0
     jsonc-parser: ^3.3.1
     ocache: ^0.1.4
     ofetch: ^2.0.0-alpha.3


### PR DESCRIPTION
In fast-npm-meta@2.1.0, `provenance` and `trustedPublisher` split into separate fields, new `staged` field. Hover now shows all three as inline badges.