### PR TITLE
feat: auto-install npmx-language-server in Zed extension via npm

### DIFF
--- a/extensions/zed/README.md
+++ b/extensions/zed/README.md
@@ -1,16 +1,8 @@
 # npmx for Zed
 
-This is the in-repo Zed extension for `npmx`. It runs the shared `npmx-language-server`
-over stdio, so Zed gets the same core package intelligence used by the VS Code extension.
+Enhance your npm package workflow in Zed.
 
-## Status
-
-- Uses the shared `npmx-language-server`
-- Targets local development from this monorepo first
-- Defaults to `packages/language-server/dist/index.cjs`
-- Launches the language server over `--stdio`
-- Supports overriding the launched command through Zed `lsp.npmx.binary` settings
-- Forwards `lsp.npmx.settings` to the language server as `npmx` workspace configuration
+This extension runs the `npmx-language-server` — the same language server used by the VS Code version — over stdio. The server version is pinned to the extension version and auto-installed from npm when needed.
 
 ## Features
 
@@ -21,16 +13,9 @@ over stdio, so Zed gets the same core package intelligence used by the VS Code e
 - Document links for package names
 - Workspace-aware dependency resolution for npm, pnpm, yarn, and bun projects
 
-## Local Development
-
-1. Build the language server from the repo root with `pnpm build`.
-2. In Zed, install `extensions/zed` as a dev extension.
-3. If you want a custom launch command, configure `lsp.npmx.binary` in your Zed settings.
-
 ## Settings
 
-Zed settings under `lsp.npmx.settings` are forwarded directly to the language server.
-Use scoped npmx settings without the leading `npmx.` prefix:
+Settings under `lsp.npmx.settings` are forwarded to the language server as `npmx` workspace configuration. Use scoped npmx settings without the leading `npmx.` prefix:
 
 ```json
 {
@@ -59,7 +44,7 @@ Use scoped npmx settings without the leading `npmx.` prefix:
 }
 ```
 
-To override the launched language server command:
+To override the language server command (e.g. for local development):
 
 ```json
 {
@@ -77,8 +62,19 @@ To override the launched language server command:
 }
 ```
 
+## Local Development
+
+1. Build the language server from the repo root with `pnpm build`.
+2. Configure `lsp.npmx.binary` in Zed settings pointing to the local build (see above).
+3. Install `extensions/zed` as a dev extension in Zed.
+
+## Publishing
+
+1. Bump version in `Cargo.toml`, `extension.toml`, and `packages/language-server/package.json`.
+2. Build the monorepo and publish `npmx-language-server` to npm.
+3. Open a PR to [zed-industries/extensions](https://github.com/zed-industries/extensions) updating the submodule and version.
+
 ## Notes
 
 - Zed dev extensions require Rust installed via `rustup`; the Zed docs explicitly call out that Homebrew Rust will not work for dev extension compilation.
-- This dev extension expects the repo-local language server bundle at `packages/language-server/dist/index.cjs`, so build the monorepo before installing it in Zed.
-- If you override `lsp.npmx.binary`, make sure the launched server process still receives an LSP transport argument such as `--stdio`.
+- The language server version is pinned to the extension's `Cargo.toml` version. It auto-installs via the Zed npm API when the extension activates.

--- a/extensions/zed/src/lib.rs
+++ b/extensions/zed/src/lib.rs
@@ -15,7 +15,6 @@ impl NpmxExtension {
     }
 
     fn server_binary(worktree: &zed::Worktree, lsp_settings: &LspSettings) -> Result<zed::Command> {
-        // 1. User override via lsp.npmx.binary
         if let Some(binary) = &lsp_settings.binary {
             let command = match &binary.path {
                 Some(path) => path.clone(),
@@ -30,7 +29,6 @@ impl NpmxExtension {
             return Ok(zed::Command { command, args, env });
         }
 
-        // 2. Install or update npm package pinned to Cargo.toml version
         let version = env!("CARGO_PKG_VERSION");
 
         let installed = zed::npm_package_installed_version(PACKAGE_NAME)?;

--- a/extensions/zed/src/lib.rs
+++ b/extensions/zed/src/lib.rs
@@ -1,4 +1,6 @@
-use zed_extension_api::{self as zed, LanguageServerId, serde_json, settings::LspSettings};
+use zed_extension_api::{self as zed, LanguageServerId, Result, serde_json, settings::LspSettings};
+
+const PACKAGE_NAME: &str = "npmx-language-server";
 
 struct NpmxExtension;
 
@@ -12,11 +14,39 @@ impl NpmxExtension {
             .unwrap_or_default()
     }
 
-    fn default_server_script() -> String {
-        format!(
-            "{}/../../packages/language-server/dist/index.cjs",
-            env!("CARGO_MANIFEST_DIR")
-        )
+    fn server_binary(worktree: &zed::Worktree, lsp_settings: &LspSettings) -> Result<zed::Command> {
+        // 1. User override via lsp.npmx.binary
+        if let Some(binary) = &lsp_settings.binary {
+            let command = match &binary.path {
+                Some(path) => path.clone(),
+                None => zed::node_binary_path()?,
+            };
+            let args = binary.arguments.clone().unwrap_or_default();
+            let env = worktree
+                .shell_env()
+                .into_iter()
+                .chain(binary.env.clone().unwrap_or_default())
+                .collect();
+            return Ok(zed::Command { command, args, env });
+        }
+
+        // 2. Install or update npm package pinned to Cargo.toml version
+        let version = env!("CARGO_PKG_VERSION");
+
+        let installed = zed::npm_package_installed_version(PACKAGE_NAME)?;
+        if installed.as_deref() != Some(version) {
+            zed::npm_install_package(PACKAGE_NAME, version)?;
+        }
+
+        let node = zed::node_binary_path()?;
+        Ok(zed::Command {
+            command: node,
+            args: vec![
+                format!("node_modules/.bin/{PACKAGE_NAME}"),
+                "--stdio".to_string(),
+            ],
+            env: worktree.shell_env().into_iter().collect(),
+        })
     }
 }
 
@@ -31,26 +61,7 @@ impl zed::Extension for NpmxExtension {
         worktree: &zed::Worktree,
     ) -> zed::Result<zed::Command> {
         let lsp_settings = Self::language_server_settings(language_server_id, worktree);
-        if let Some(binary) = lsp_settings.binary {
-            let command = match binary.path {
-                Some(path) => path,
-                None => zed::node_binary_path()?,
-            };
-            let args = binary.arguments.unwrap_or_default();
-            let env = worktree
-                .shell_env()
-                .into_iter()
-                .chain(binary.env.unwrap_or_default())
-                .collect();
-
-            return Ok(zed::Command { command, args, env });
-        }
-
-        Ok(zed::Command {
-            command: zed::node_binary_path()?,
-            args: vec![Self::default_server_script(), String::from("--stdio")],
-            env: worktree.shell_env().into_iter().collect(),
-        })
+        Self::server_binary(worktree, &lsp_settings)
     }
 
     fn language_server_initialization_options(

--- a/extensions/zed/src/lib.rs
+++ b/extensions/zed/src/lib.rs
@@ -15,18 +15,21 @@ impl NpmxExtension {
     }
 
     fn server_binary(worktree: &zed::Worktree, lsp_settings: &LspSettings) -> Result<zed::Command> {
+        let mut env: Vec<(String, String)> = worktree.shell_env().into_iter().collect();
+
         if let Some(binary) = &lsp_settings.binary {
-            let command = match &binary.path {
-                Some(path) => path.clone(),
-                None => zed::node_binary_path()?,
-            };
-            let args = binary.arguments.clone().unwrap_or_default();
-            let env = worktree
-                .shell_env()
-                .into_iter()
-                .chain(binary.env.clone().unwrap_or_default())
-                .collect();
-            return Ok(zed::Command { command, args, env });
+            if let Some(binary_env) = &binary.env {
+                env.extend(binary_env.clone());
+            }
+
+            if binary.path.is_some() || binary.arguments.is_some() {
+                let command = match &binary.path {
+                    Some(path) => path.clone(),
+                    None => zed::node_binary_path()?,
+                };
+                let args = binary.arguments.clone().unwrap_or_default();
+                return Ok(zed::Command { command, args, env });
+            }
         }
 
         let version = env!("CARGO_PKG_VERSION");
@@ -40,10 +43,10 @@ impl NpmxExtension {
         Ok(zed::Command {
             command: node,
             args: vec![
-                format!("node_modules/.bin/{PACKAGE_NAME}"),
+                format!("node_modules/{PACKAGE_NAME}/dist/index.cjs"),
                 "--stdio".to_string(),
             ],
-            env: worktree.shell_env().into_iter().collect(),
+            env,
         })
     }
 }


### PR DESCRIPTION
Replace local dev path with Zed npm API. The extension now installs npmx-language-server from npm pinned to the extension version at activation time.