### PR TITLE
chore: release v0.9.3

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -3,7 +3,7 @@
   "name": "vscode-npmx",
   "displayName": "npmx",
   "type": "module",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Enhance your npm package workflow in VS Code",
   "author": {
     "name": "Vida Xie",

--- a/extensions/zed/Cargo.toml
+++ b/extensions/zed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed-npmx"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 license = "MIT"
 publish = false

--- a/extensions/zed/extension.toml
+++ b/extensions/zed/extension.toml
@@ -1,7 +1,7 @@
 id = "npmx-language-server"
 name = "Npmx Language Server"
 description = "Enhance your npm package workflow in Zed"
-version = "0.9.2"
+version = "0.9.3"
 schema_version = 1
 authors = [
   "npmx-dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "npmx-extensions-monorepo",
   "type": "module",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "private": true,
   "packageManager": "pnpm@11.22.0",
   "author": {

--- a/packages/language-core/package.json
+++ b/packages/language-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "npmx-language-core",
   "type": "module",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "private": true,
   "license": "MIT",
   "repository": {

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "npmx-language-server",
   "type": "module",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "npmx-language-service",
   "type": "module",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "private": true,
   "license": "MIT",
   "repository": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,7 +1,7 @@
 {
   "name": "npmx-shared",
   "type": "module",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "private": true,
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Release `v0.9.3` (`0.9.2` → `0.9.3`).

### Features

- upgrade deps (#149) (120a6d7)

### Bug Fixes

- **language-server**: convert URI path to filesystem path for package manager detection (#147) (7d1a611)
- **zed**: resolve language server binary path to absolute (639d309)

### Refactors

- **deps**: migrate semver to verkit (#145) (85de7c8)

### Build

- **deps**: bump e18e/action-dependency-diff (#146) (15f8824)
- **deps**: bump actions/checkout from 7.0.0 to 7.0.1 (#144) (31d5916)
- **deps**: bump e18e/action-dependency-diff (#143) (86530eb)

### CI

- drive releases through pull requests (#150) (f1472a7)
- use bumpp --all to include zed files in release commit (c116098)

### Chores

- **zed**: align zed extension id (4554f47)
- **zed**: update authors (aac194f)
- configure rust-analyzer to pick up Zed extension (9beb715)