### PR TITLE
fix(language-server): replace unsupported `ocache` maxAge `-1` with safe maximum

### DIFF
--- a/packages/language-core/src/constants.ts
+++ b/packages/language-core/src/constants.ts
@@ -7,5 +7,18 @@ export const DEPENDENCY_FILE_GLOB = `**/{${PACKAGE_JSON_BASENAME},${PNPM_WORKSPA
 
 export const CACHE_MAX_AGE_ONE_DAY = 60 * 60 * 24
 
+/**
+ * The maximum cache age (in seconds) accepted by `ocache`'s `maxAge` option.
+ *
+ * This is the largest whole number of seconds that can be expressed within a
+ * 32-bit signed integer (`(2 ** 31 - 1) / 1000 ≈ 596523` hours). It acts as a
+ * safe upper bound for caches that should effectively live forever.
+ *
+ * This was introduced to cope with a breaking change in `ocache`: the previous
+ * idiom of passing `-1` to disable expiration is no longer supported, so we
+ * pass the largest valid `maxAge` instead to keep entries from expiring.
+ */
+export const CACHE_MAX_AGE_MAXIMUM = Math.trunc((2 ** 31 - 1) / 1000)
+
 export const NPMX_DEV = 'https://npmx.dev'
 export const NPMX_DEV_API = `${NPMX_DEV}/api`

--- a/packages/language-server/src/workspace.ts
+++ b/packages/language-server/src/workspace.ts
@@ -2,7 +2,7 @@ import type { Connection, LanguageServer } from '@volar/language-server'
 import type { DependencyInfo, PackageManager, WorkspaceAdapter } from 'npmx-language-core/workspace'
 import type { ClientFeatures, IWorkspaceState } from 'npmx-language-service/types'
 import { access, realpath as fsRealpath, readFile } from 'node:fs/promises'
-import { DEPENDENCY_FILE_GLOB, PACKAGE_JSON_BASENAME } from 'npmx-language-core/constants'
+import { CACHE_MAX_AGE_MAXIMUM, DEPENDENCY_FILE_GLOB, PACKAGE_JSON_BASENAME } from 'npmx-language-core/constants'
 import { isDependencyFile, isPackageManifest } from 'npmx-language-core/utils'
 import { WorkspaceContext } from 'npmx-language-core/workspace'
 import { DEFAULT_CLIENT_FEATURES } from 'npmx-language-service/types'
@@ -139,7 +139,7 @@ export class WorkspaceState implements IWorkspaceState {
     {
       name: 'workspace-context',
       getKey: (folderUri) => folderUri.path,
-      maxAge: -1,
+      maxAge: CACHE_MAX_AGE_MAXIMUM,
       swr: false,
       staleMaxAge: 0,
     },


### PR DESCRIPTION
`ocache` dropped support for passing `-1` to disable cache expiration. Introduce `CACHE_MAX_AGE_MAXIMUM` (largest valid 32-bit signed seconds) and use it for the workspace-context cache to keep entries from expiring.

<img width="1920" height="1020" alt="屏幕截图 2026-08-23 163224" src="https://github.com/user-attachments/assets/a06c2019-2786-4ac0-9ce7-e93230713ec1" />
